### PR TITLE
fix: improve toast description text contrast

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -15,6 +15,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           '--normal-bg': 'var(--popover)',
           '--normal-text': 'var(--popover-foreground)',
           '--normal-border': 'var(--border)',
+          '--normal-description': 'var(--muted-foreground)',
         } as React.CSSProperties
       }
       {...props}


### PR DESCRIPTION
Add --normal-description CSS variable to Sonner toaster to ensure
description text has proper contrast using muted-foreground color.