### PR TITLE
fix: filter out deleted categories when joining transactions

### DIFF
--- a/src/server/routers/dashboard.ts
+++ b/src/server/routers/dashboard.ts
@@ -92,7 +92,13 @@ export const dashboardRouter = router({
           transactionCount: sql<number>`count(*)`,
         })
         .from(transaction)
-        .leftJoin(category, eq(transaction.categoryId, category.id))
+        .leftJoin(
+          category,
+          and(
+            eq(transaction.categoryId, category.id),
+            eq(category.deleted, false),
+          ),
+        )
         .where(
           and(
             eq(transaction.userId, ctx.user.id),

--- a/src/server/routers/transactions.ts
+++ b/src/server/routers/transactions.ts
@@ -106,7 +106,13 @@ export const transactionsRouter = router({
           createdAt: transaction.createdAt,
         })
         .from(transaction)
-        .leftJoin(category, eq(transaction.categoryId, category.id))
+        .leftJoin(
+          category,
+          and(
+            eq(transaction.categoryId, category.id),
+            eq(category.deleted, false),
+          ),
+        )
         .where(and(...whereClauses))
         .orderBy(desc(transaction.date), desc(transaction.id))
         .limit(input.pagination.limit + 1)
@@ -301,7 +307,13 @@ export const transactionsRouter = router({
         categoryName: category.name,
       })
       .from(transaction)
-      .leftJoin(category, eq(transaction.categoryId, category.id))
+      .leftJoin(
+        category,
+        and(
+          eq(transaction.categoryId, category.id),
+          eq(category.deleted, false),
+        ),
+      )
       .where(
         and(
           eq(transaction.userId, ctx.user.id),
@@ -350,7 +362,13 @@ export const transactionsRouter = router({
         currency: transaction.currency,
       })
       .from(transaction)
-      .leftJoin(category, eq(transaction.categoryId, category.id))
+      .leftJoin(
+        category,
+        and(
+          eq(transaction.categoryId, category.id),
+          eq(category.deleted, false),
+        ),
+      )
       .where(
         and(
           eq(transaction.userId, ctx.user.id),


### PR DESCRIPTION
When listing transactions with category joins, deleted categories
were still being returned. Updated leftJoin conditions to exclude
categories marked as deleted in:
- transactions.list
- transactions.getMostFrequentCategory
- transactions.getMostExpensiveCategory
- dashboard.getSpendingByCategory