### PR TITLE
feat: add Cmd+A/Ctrl+A keyboard shortcut to select all table rows

### DIFF
--- a/src/components/logged-in/categories/categories-table.tsx
+++ b/src/components/logged-in/categories/categories-table.tsx
@@ -13,6 +13,7 @@ import { useBulkSelection } from '@/hooks/use-bulk-selection'
 import { useCategories } from '@/hooks/use-categories'
 import { trpc } from '@/lib/trpc/client'
 import { useMemo } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
 import { toast } from 'sonner'
 import { FloatingActionBar } from '../bulk-actions/floating-action-bar'
 import { EmptyState } from '../empty-state'
@@ -35,8 +36,11 @@ export function CategoriesTable() {
     isPartiallySelected,
     handleClick,
     toggleAll,
+    selectAll,
     clearSelection,
   } = useBulkSelection({ itemIds })
+
+  useHotkeys('mod+a', selectAll, { preventDefault: true })
 
   const { mutate: deleteMany, isPending: isDeleting } =
     trpc.categories.deleteMany.useMutation({

--- a/src/components/logged-in/categorization-rules/categorization-rules-table.tsx
+++ b/src/components/logged-in/categorization-rules/categorization-rules-table.tsx
@@ -29,6 +29,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { useMemo } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
 import { toast } from 'sonner'
 import { FloatingActionBar } from '../bulk-actions/floating-action-bar'
 import { EmptyState } from '../empty-state'
@@ -65,8 +66,11 @@ export function CategorizationRulesTable() {
     isPartiallySelected,
     handleClick,
     toggleAll,
+    selectAll,
     clearSelection,
   } = useBulkSelection({ itemIds })
+
+  useHotkeys('mod+a', selectAll, { preventDefault: true })
 
   const { mutate: deleteMany, isPending: isDeleting } =
     trpc.categorizationRules.deleteMany.useMutation({

--- a/src/components/logged-in/transactions/transactions-table.tsx
+++ b/src/components/logged-in/transactions/transactions-table.tsx
@@ -13,6 +13,7 @@ import { useBulkSelection } from '@/hooks/use-bulk-selection'
 import { useTransactions } from '@/hooks/use-transactions'
 import { trpc } from '@/lib/trpc/client'
 import { useMemo } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
 import { toast } from 'sonner'
 import { FloatingActionBar } from '../bulk-actions/floating-action-bar'
 import { EmptyState } from '../empty-state'
@@ -35,8 +36,11 @@ export const TransactionsTable = () => {
     isPartiallySelected,
     handleClick,
     toggleAll,
+    selectAll,
     clearSelection,
   } = useBulkSelection({ itemIds })
+
+  useHotkeys('mod+a', selectAll, { preventDefault: true })
 
   const { mutate: deleteMany, isPending: isDeleting } =
     trpc.transactions.deleteMany.useMutation({

--- a/src/components/logged-in/uploads/uploads-table.tsx
+++ b/src/components/logged-in/uploads/uploads-table.tsx
@@ -21,6 +21,7 @@ import { useUploads } from '@/hooks/use-uploads'
 import { trpc } from '@/lib/trpc/client'
 import { IconInfoCircle } from '@tabler/icons-react'
 import { useMemo, useState } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
 import { toast } from 'sonner'
 import { FloatingActionBar } from '../bulk-actions/floating-action-bar'
 import { EmptyState } from '../empty-state'
@@ -45,8 +46,11 @@ export function UploadsTable() {
     isPartiallySelected,
     handleClick,
     toggleAll,
+    selectAll,
     clearSelection,
   } = useBulkSelection({ itemIds })
+
+  useHotkeys('mod+a', selectAll, { preventDefault: true })
 
   const { mutate: deleteMany, isPending: isDeleting } =
     trpc.uploads.deleteMany.useMutation({

--- a/src/hooks/use-bulk-selection.ts
+++ b/src/hooks/use-bulk-selection.ts
@@ -110,12 +110,18 @@ export function useBulkSelection({ itemIds }: UseBulkSelectionOptions) {
     lastSelectedIdRef.current = null
   }, [])
 
+  const selectAll = useCallback(() => {
+    setSelectedIds(new Set(itemIds))
+    lastSelectedIdRef.current = null
+  }, [itemIds])
+
   return {
     selectedIds,
     isAllSelected,
     isPartiallySelected,
     handleClick,
     toggleAll,
+    selectAll,
     clearSelection,
   }
 }


### PR DESCRIPTION
Add keyboard shortcut to select all rows for bulk operations on
transactions, categories, uploads, and categorization-rules tables.