### PR TITLE
fix: use sentence case for all UI titles and labels

### DIFF
--- a/src/components/logged-in/uploads/uploads-table.tsx
+++ b/src/components/logged-in/uploads/uploads-table.tsx
@@ -83,10 +83,10 @@ export function UploadsTable() {
         <Table containerClassName="overflow-visible">
           <TableHeader>
             <TableRow>
-              <TableHead className="w-[35%]">File Name</TableHead>
-              <TableHead className="w-[15%]">File Size</TableHead>
+              <TableHead className="w-[35%]">File name</TableHead>
+              <TableHead className="w-[15%]">File size</TableHead>
               <TableHead className="w-[15%]">Status</TableHead>
-              <TableHead className="w-[20%]">Uploaded At</TableHead>
+              <TableHead className="w-[20%]">Uploaded at</TableHead>
               <TableHead className="w-[15%]">Actions</TableHead>
             </TableRow>
           </TableHeader>

--- a/src/components/settings/backup-codes-dialog.tsx
+++ b/src/components/settings/backup-codes-dialog.tsx
@@ -151,7 +151,7 @@ export function BackupCodesDialog({
                 onClick={handleGetBackupCodes}
                 disabled={isLoading || !password}
               >
-                {isLoading ? 'Verifying...' : 'View Codes'}
+                {isLoading ? 'Verifying...' : 'View codes'}
               </Button>
             </DialogFooter>
           </>


### PR DESCRIPTION
- Change "View Codes" to "View codes" in backup codes dialog
- Change "File Name" to "File name" in uploads table
- Change "File Size" to "File size" in uploads table
- Change "Uploaded At" to "Uploaded at" in uploads table