### PR TITLE
feat: hide bulk operation checkboxes on mobile devices

### DIFF
--- a/src/components/logged-in/categories/categories-table.tsx
+++ b/src/components/logged-in/categories/categories-table.tsx
@@ -11,6 +11,7 @@ import {
 import { TableHeader } from '@/components/ui/table'
 import { useBulkSelection } from '@/hooks/use-bulk-selection'
 import { useCategories } from '@/hooks/use-categories'
+import { useIsMobile } from '@/hooks/use-is-mobile'
 import { trpc } from '@/lib/trpc/client'
 import { useMemo } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -23,6 +24,7 @@ import { CategoriesFilters } from './filters'
 import { LoadingState } from './loading-state'
 
 export function CategoriesTable() {
+  const isMobile = useIsMobile()
   const { data: categories, isLoading, refetch } = useCategories()
 
   const itemIds = useMemo(
@@ -40,7 +42,7 @@ export function CategoriesTable() {
     clearSelection,
   } = useBulkSelection({ itemIds })
 
-  useHotkeys('mod+a', selectAll, { preventDefault: true })
+  useHotkeys('mod+a', selectAll, { preventDefault: true, enabled: !isMobile })
 
   const { mutate: deleteMany, isPending: isDeleting } =
     trpc.categories.deleteMany.useMutation({
@@ -66,7 +68,7 @@ export function CategoriesTable() {
           checked={isAllSelected}
           indeterminate={isPartiallySelected}
           onCheckedChange={toggleAll}
-          className="absolute -left-8 top-2.5 opacity-0 hover:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100"
+          className="absolute -left-8 top-2.5 hidden opacity-0 hover:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 md:block"
           aria-label="Select all categories"
         />
         <Table containerClassName="overflow-visible">

--- a/src/components/logged-in/categories/category-item.tsx
+++ b/src/components/logged-in/categories/category-item.tsx
@@ -44,7 +44,7 @@ export function CategoryItem({
         <Checkbox
           checked={isSelected}
           onClick={(e) => onSelect?.(category.id, e)}
-          className="absolute -left-8 top-3 opacity-0 group-hover:opacity-100 data-[state=checked]:opacity-100"
+          className="absolute -left-8 top-3 hidden opacity-0 group-hover:opacity-100 data-[state=checked]:opacity-100 md:block"
           aria-label={`Select category ${category.name}`}
         />
         <InternalLink href={`/transactions?category=${category.id}`}>

--- a/src/components/logged-in/categorization-rules/categorization-rules-table.tsx
+++ b/src/components/logged-in/categorization-rules/categorization-rules-table.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { useBulkSelection } from '@/hooks/use-bulk-selection'
+import { useIsMobile } from '@/hooks/use-is-mobile'
 import { usePagination } from '@/hooks/use-pagination'
 import { trpc } from '@/lib/trpc/client'
 import {
@@ -39,6 +40,7 @@ import { RuleItem } from './rule-item'
 import { RulesPagination } from './rules-pagination'
 
 export function CategorizationRulesTable() {
+  const isMobile = useIsMobile()
   const { filters } = useCategorizationRulesFilters()
   const { pagination } = usePagination()
   const utils = trpc.useUtils()
@@ -70,7 +72,7 @@ export function CategorizationRulesTable() {
     clearSelection,
   } = useBulkSelection({ itemIds })
 
-  useHotkeys('mod+a', selectAll, { preventDefault: true })
+  useHotkeys('mod+a', selectAll, { preventDefault: true, enabled: !isMobile })
 
   const { mutate: deleteMany, isPending: isDeleting } =
     trpc.categorizationRules.deleteMany.useMutation({
@@ -152,7 +154,7 @@ export function CategorizationRulesTable() {
           checked={isAllSelected}
           indeterminate={isPartiallySelected}
           onCheckedChange={toggleAll}
-          className="absolute -left-8 top-2.5 opacity-0 hover:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100"
+          className="absolute -left-8 top-2.5 hidden opacity-0 hover:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 md:block"
           aria-label="Select all rules"
         />
         <Table containerClassName="overflow-visible">

--- a/src/components/logged-in/categorization-rules/rule-item.tsx
+++ b/src/components/logged-in/categorization-rules/rule-item.tsx
@@ -107,7 +107,7 @@ export function RuleItem({
         <Checkbox
           checked={isSelected}
           onClick={(e) => onSelect?.(rule.id, e)}
-          className="absolute -left-8 top-3 opacity-0 group-hover:opacity-100 data-[state=checked]:opacity-100"
+          className="absolute -left-8 top-3 hidden opacity-0 group-hover:opacity-100 data-[state=checked]:opacity-100 md:block"
           aria-label={`Select rule ${rule.name}`}
         />
         <button

--- a/src/components/logged-in/transactions/transaction-item.tsx
+++ b/src/components/logged-in/transactions/transaction-item.tsx
@@ -61,7 +61,7 @@ export function TransactionItem({
         <Checkbox
           checked={isSelected}
           onClick={(e) => onSelect?.(transaction.id, e)}
-          className="absolute -left-8 top-3 opacity-0 group-hover:opacity-100 data-[state=checked]:opacity-100"
+          className="absolute -left-8 top-3 hidden opacity-0 group-hover:opacity-100 data-[state=checked]:opacity-100 md:block"
           aria-label={`Select transaction ${transaction.merchantName}`}
         />
         {format(parseISO(transaction.date), 'MMM d, yyyy')}

--- a/src/components/logged-in/transactions/transactions-table.tsx
+++ b/src/components/logged-in/transactions/transactions-table.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/table'
 import { TableHeader } from '@/components/ui/table'
 import { useBulkSelection } from '@/hooks/use-bulk-selection'
+import { useIsMobile } from '@/hooks/use-is-mobile'
 import { useTransactions } from '@/hooks/use-transactions'
 import { trpc } from '@/lib/trpc/client'
 import { useMemo } from 'react'
@@ -23,6 +24,7 @@ import { TransactionItem } from './transaction-item'
 import { TransactionsPagination } from './transactions-pagination'
 
 export const TransactionsTable = () => {
+  const isMobile = useIsMobile()
   const { data: transactions, isLoading, refetch } = useTransactions()
 
   const itemIds = useMemo(
@@ -40,7 +42,7 @@ export const TransactionsTable = () => {
     clearSelection,
   } = useBulkSelection({ itemIds })
 
-  useHotkeys('mod+a', selectAll, { preventDefault: true })
+  useHotkeys('mod+a', selectAll, { preventDefault: true, enabled: !isMobile })
 
   const { mutate: deleteMany, isPending: isDeleting } =
     trpc.transactions.deleteMany.useMutation({
@@ -66,7 +68,7 @@ export const TransactionsTable = () => {
           checked={isAllSelected}
           indeterminate={isPartiallySelected}
           onCheckedChange={toggleAll}
-          className="absolute -left-8 top-2.5 opacity-0 hover:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100"
+          className="absolute -left-8 top-2.5 hidden opacity-0 hover:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 md:block"
           aria-label="Select all transactions"
         />
         <Table containerClassName="overflow-visible">

--- a/src/components/logged-in/uploads/upload-item.tsx
+++ b/src/components/logged-in/uploads/upload-item.tsx
@@ -88,7 +88,7 @@ export function UploadItem({
         <Checkbox
           checked={isSelected}
           onClick={(e) => onSelect?.(upload.id, e)}
-          className="absolute -left-8 top-3 opacity-0 group-hover:opacity-100 data-[state=checked]:opacity-100"
+          className="absolute -left-8 top-3 hidden opacity-0 group-hover:opacity-100 data-[state=checked]:opacity-100 md:block"
           aria-label={`Select upload ${upload.fileName}`}
         />
         <FileName fileName={upload.fileName} metadata={upload.metadata} />

--- a/src/components/logged-in/uploads/uploads-table.tsx
+++ b/src/components/logged-in/uploads/uploads-table.tsx
@@ -17,6 +17,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useBulkSelection } from '@/hooks/use-bulk-selection'
+import { useIsMobile } from '@/hooks/use-is-mobile'
 import { useUploads } from '@/hooks/use-uploads'
 import { trpc } from '@/lib/trpc/client'
 import { IconInfoCircle } from '@tabler/icons-react'
@@ -31,6 +32,7 @@ import { UploadItem } from './upload-item'
 import { UploadsPagination } from './uploads-pagination'
 
 export function UploadsTable() {
+  const isMobile = useIsMobile()
   const { data: uploads, isLoading, refetch } = useUploads()
   const [deleteRelatedTransactions, setDeleteRelatedTransactions] =
     useState(false)
@@ -50,7 +52,7 @@ export function UploadsTable() {
     clearSelection,
   } = useBulkSelection({ itemIds })
 
-  useHotkeys('mod+a', selectAll, { preventDefault: true })
+  useHotkeys('mod+a', selectAll, { preventDefault: true, enabled: !isMobile })
 
   const { mutate: deleteMany, isPending: isDeleting } =
     trpc.uploads.deleteMany.useMutation({
@@ -77,7 +79,7 @@ export function UploadsTable() {
           checked={isAllSelected}
           indeterminate={isPartiallySelected}
           onCheckedChange={toggleAll}
-          className="absolute -left-8 top-2.5 opacity-0 hover:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100"
+          className="absolute -left-8 top-2.5 hidden opacity-0 hover:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 md:block"
           aria-label="Select all uploads"
         />
         <Table containerClassName="overflow-visible">


### PR DESCRIPTION
Bulk selection is now desktop-only for better mobile UX:
- Hide select-all checkboxes in table headers on mobile
- Hide row-level selection checkboxes on mobile
- Disable Cmd+A keyboard shortcut on mobile

Affects transactions, categories, uploads, and categorization rules tables.