### PR TITLE
fix: ui improvements for toast messages, pagination buttons, and bulk selection

### DIFF
--- a/src/components/logged-in/nav-main.tsx
+++ b/src/components/logged-in/nav-main.tsx
@@ -44,14 +44,16 @@ export function NavMain({ items }: NavMainProps) {
     trpc.uploads.createSignedUploadUrls.useMutation({
       onMutate: () => {
         setIsUploading(true)
-        toast.loading('Preparing bank statement upload...', {
+        toast.loading('Preparing bank statements upload...', {
           id: 'upload-bank-statement',
+          description: null,
         })
       },
       onError: (error) => {
         setIsUploading(false)
         toast.error(error.message, {
           id: 'upload-bank-statement',
+          description: null,
         })
       },
       onSuccess: async ({ uploadUrls }) => {
@@ -79,6 +81,7 @@ export function NavMain({ items }: NavMainProps) {
 
     toast.loading('Uploading bank statements...', {
       id: 'upload-bank-statement',
+      description: null,
     })
 
     const successfulUploads: {
@@ -109,11 +112,13 @@ export function NavMain({ items }: NavMainProps) {
     onMutate: () => {
       toast.loading('Processing bank statements...', {
         id: 'upload-bank-statement',
+        description: null,
       })
     },
     onError: (error) => {
       toast.error(error.message, {
         id: 'upload-bank-statement',
+        description: null,
       })
     },
     onSuccess: () => {

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -52,7 +52,7 @@ type PaginationLinkProps = {
 function PaginationLink({
   className,
   isActive,
-  size = 'icon',
+  size = 'sm',
   ...props
 }: PaginationLinkProps) {
   return (

--- a/src/hooks/use-bulk-selection.ts
+++ b/src/hooks/use-bulk-selection.ts
@@ -111,9 +111,14 @@ export function useBulkSelection({ itemIds }: UseBulkSelectionOptions) {
   }, [])
 
   const selectAll = useCallback(() => {
+    if (isAllSelected) {
+      setSelectedIds(new Set())
+      return
+    }
+
     setSelectedIds(new Set(itemIds))
     lastSelectedIdRef.current = null
-  }, [itemIds])
+  }, [itemIds, isAllSelected])
 
   return {
     selectedIds,


### PR DESCRIPTION
## Summary
- Clear toast descriptions when updating toast state to avoid stale descriptions showing from previous states
- Fix pagination link button size from 'icon' to 'sm' for better clickability
- Toggle all selection off when pressing Mod+A while all items are already selected