### PR TITLE
fix: filter deleted categories in AI import task

### DIFF
--- a/src/trigger/ai/categorize-and-import-transactions.ts
+++ b/src/trigger/ai/categorize-and-import-transactions.ts
@@ -64,7 +64,7 @@ export const categorizeAndImportTransactionsTask = task({
     const categories = await db
       .select({ id: category.id, name: category.name })
       .from(category)
-      .where(eq(category.userId, userId))
+      .where(and(eq(category.userId, userId), eq(category.deleted, false)))
     logger.info(
       `Found ${categories.length} categories for the user ${userId}:`,
       {
@@ -238,6 +238,7 @@ ${pdfText}`,
         .where(
           and(
             eq(category.userId, upToDateUpload.userId),
+            eq(category.deleted, false),
             inArray(category.name, uniqueCategories),
           ),
         )


### PR DESCRIPTION
## Summary
- Add `deleted=false` filter to category queries in AI import task
- Prevents transactions from being assigned to soft-deleted categories
- Fixes bug where transactions showed "Uncategorized" despite having category_id set

## Root cause
Category queries in `categorize-and-import-transactions.ts` were missing the `deleted=false` filter. When deleted categories matched by name, transactions got assigned those categoryIds. The transaction list query's LEFT JOIN filters by `category.deleted=false`, so deleted categories don't match → shows "Uncategorized".