### PR TITLE
feat: pagination records per page selector

### DIFF
--- a/src/components/logged-in/categories/categories-pagination.tsx
+++ b/src/components/logged-in/categories/categories-pagination.tsx
@@ -17,7 +17,7 @@ interface CategoriesPaginationProps {
 }
 
 export function CategoriesPagination({ hasMore }: CategoriesPaginationProps) {
-  const { pagination, setPagination } = usePagination()
+  const { pagination, setPagination } = usePagination('categories')
 
   const currentPage = pagination.page
   const hasNextPage = hasMore

--- a/src/components/logged-in/categories/filters/search-filter.tsx
+++ b/src/components/logged-in/categories/filters/search-filter.tsx
@@ -18,7 +18,7 @@ const SEARCH_SHORTCUT = 'S'
 
 export function SearchFilter() {
   const { categoryFilters, setCategoryFilters } = useCategoriesFilters()
-  const { setPagination } = usePagination()
+  const { setPagination } = usePagination('categories')
   const inputRef = useRef<HTMLInputElement>(null)
 
   const debouncedSetSearchParams = useDebounceCallback((value: string) => {

--- a/src/components/logged-in/categories/loading-state.tsx
+++ b/src/components/logged-in/categories/loading-state.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils'
 const RANDOM_FIRST_COLUMN_SIZES = ['h-3.5 w-48', 'h-3.5 w-40', 'h-3.5 w-52']
 
 export function LoadingState() {
-  const { pagination } = usePagination()
+  const { pagination } = usePagination('categories')
 
   return (
     <>

--- a/src/components/logged-in/categorization-rules/categorization-rules-table.tsx
+++ b/src/components/logged-in/categorization-rules/categorization-rules-table.tsx
@@ -42,7 +42,7 @@ import { RulesPagination } from './rules-pagination'
 export function CategorizationRulesTable() {
   const isMobile = useIsMobile()
   const { filters } = useCategorizationRulesFilters()
-  const { pagination } = usePagination()
+  const { pagination } = usePagination('categorization-rules')
   const utils = trpc.useUtils()
 
   const queryKey = {

--- a/src/components/logged-in/categorization-rules/filters/search-filter.tsx
+++ b/src/components/logged-in/categorization-rules/filters/search-filter.tsx
@@ -18,7 +18,7 @@ const SEARCH_SHORTCUT = 'S'
 
 export function SearchFilter() {
   const { filters, setFilters } = useCategorizationRulesFilters()
-  const { setPagination } = usePagination()
+  const { setPagination } = usePagination('categorization-rules')
   const inputRef = useRef<HTMLInputElement>(null)
 
   const debouncedSetSearchParams = useDebounceCallback((value: string) => {

--- a/src/components/logged-in/categorization-rules/loading-state.tsx
+++ b/src/components/logged-in/categorization-rules/loading-state.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils'
 const RANDOM_NAME_SIZES = ['h-3.5 w-32', 'h-3.5 w-40', 'h-3.5 w-28']
 
 export function LoadingState() {
-  const { pagination } = usePagination()
+  const { pagination } = usePagination('categorization-rules')
 
   return (
     <>

--- a/src/components/logged-in/categorization-rules/rules-pagination.tsx
+++ b/src/components/logged-in/categorization-rules/rules-pagination.tsx
@@ -17,7 +17,7 @@ interface RulesPaginationProps {
 }
 
 export function RulesPagination({ hasMore }: RulesPaginationProps) {
-  const { pagination, setPagination } = usePagination()
+  const { pagination, setPagination } = usePagination('categorization-rules')
 
   const currentPage = pagination.page
   const hasNextPage = hasMore

--- a/src/components/logged-in/transactions/filters/badges/most-expensive-category.tsx
+++ b/src/components/logged-in/transactions/filters/badges/most-expensive-category.tsx
@@ -19,7 +19,7 @@ const MOST_EXPENSIVE_CATEGORY_SHORTCUT = '3'
 export function MostExpensiveCategory() {
   const { data: category, isLoading } = useMostExpensiveCategory()
   const { transactionFilters, setTransactionFilters } = useTransactionsFilters()
-  const { setPagination } = usePagination()
+  const { setPagination } = usePagination('transactions')
 
   useHotkeys(MOST_EXPENSIVE_CATEGORY_SHORTCUT, () => handleClick())
 

--- a/src/components/logged-in/transactions/filters/badges/most-expensive-merchant.tsx
+++ b/src/components/logged-in/transactions/filters/badges/most-expensive-merchant.tsx
@@ -19,7 +19,7 @@ const MOST_EXPENSIVE_MERCHANT_SHORTCUT = '2'
 export function MostExpensiveMerchant() {
   const { data: merchant, isLoading } = useMostExpensiveMerchant()
   const { transactionFilters, setTransactionFilters } = useTransactionsFilters()
-  const { setPagination } = usePagination()
+  const { setPagination } = usePagination('transactions')
 
   useHotkeys(MOST_EXPENSIVE_MERCHANT_SHORTCUT, () => handleClick())
 

--- a/src/components/logged-in/transactions/filters/badges/most-frequent-category.tsx
+++ b/src/components/logged-in/transactions/filters/badges/most-frequent-category.tsx
@@ -18,7 +18,7 @@ const MOST_FREQUENT_CATEGORY_SHORTCUT = '4'
 export function MostFrequentCategory() {
   const { data: category, isLoading } = useMostFrequentCategory()
   const { transactionFilters, setTransactionFilters } = useTransactionsFilters()
-  const { setPagination } = usePagination()
+  const { setPagination } = usePagination('transactions')
 
   useHotkeys(MOST_FREQUENT_CATEGORY_SHORTCUT, () => handleClick())
 

--- a/src/components/logged-in/transactions/filters/badges/most-frequent-merchant.tsx
+++ b/src/components/logged-in/transactions/filters/badges/most-frequent-merchant.tsx
@@ -18,7 +18,7 @@ const MOST_FREQUENT_MERCHANT_SHORTCUT = '5'
 export function MostFrequentMerchant() {
   const { data: merchant, isLoading } = useMostFrequentMerchant()
   const { transactionFilters, setTransactionFilters } = useTransactionsFilters()
-  const { setPagination } = usePagination()
+  const { setPagination } = usePagination('transactions')
 
   useHotkeys(MOST_FREQUENT_MERCHANT_SHORTCUT, () => handleClick())
 

--- a/src/components/logged-in/transactions/filters/badges/to-review.tsx
+++ b/src/components/logged-in/transactions/filters/badges/to-review.tsx
@@ -18,7 +18,7 @@ const TO_REVIEW_SHORTCUT = '1'
 export function ToReview() {
   const { data: transactions, isLoading } = useCountToReview()
   const { transactionFilters, setTransactionFilters } = useTransactionsFilters()
-  const { setPagination } = usePagination()
+  const { setPagination } = usePagination('transactions')
 
   useHotkeys(TO_REVIEW_SHORTCUT, () => handleClick())
 

--- a/src/components/logged-in/transactions/filters/category-filter.tsx
+++ b/src/components/logged-in/transactions/filters/category-filter.tsx
@@ -27,7 +27,7 @@ export function CategoryFilter() {
     ignorePagination: true,
   })
   const { transactionFilters, setTransactionFilters } = useTransactionsFilters()
-  const { setPagination } = usePagination()
+  const { setPagination } = usePagination('transactions')
   const [isOpen, setIsOpen] = useState(false)
 
   useHotkeys(CATEGORY_SHORTCUT, (e) => {

--- a/src/components/logged-in/transactions/filters/date-range-filter.tsx
+++ b/src/components/logged-in/transactions/filters/date-range-filter.tsx
@@ -25,7 +25,7 @@ const DATE_RANGE_SHORTCUT = 'D'
 
 export function DateRangeFilter() {
   const { transactionFilters, setTransactionFilters } = useTransactionsFilters()
-  const { setPagination } = usePagination()
+  const { setPagination } = usePagination('transactions')
   const [isOpen, setIsOpen] = useState(false)
 
   const hasValues = !!transactionFilters.from && !!transactionFilters.to

--- a/src/components/logged-in/transactions/filters/search-filter.tsx
+++ b/src/components/logged-in/transactions/filters/search-filter.tsx
@@ -18,7 +18,7 @@ const SEARCH_SHORTCUT = 'S'
 
 export function SearchFilter() {
   const { transactionFilters, setTransactionFilters } = useTransactionsFilters()
-  const { setPagination } = usePagination()
+  const { setPagination } = usePagination('transactions')
   const inputRef = useRef<HTMLInputElement>(null)
 
   const debouncedSetSearchParams = useDebounceCallback((value: string) => {

--- a/src/components/logged-in/transactions/loading-state.tsx
+++ b/src/components/logged-in/transactions/loading-state.tsx
@@ -10,7 +10,7 @@ const RANDOM_THIRD_COLUMN_SIZES = ['h-3.5 w-48', 'h-3.5 w-40', 'h-3.5 w-52']
 const RANDOM_FOURTH_COLUMN_SIZES = ['h-3.5 w-20', 'h-3.5 w-24', 'h-3.5 w-28']
 
 export function LoadingState() {
-  const { pagination } = usePagination()
+  const { pagination } = usePagination('transactions')
 
   return (
     <>

--- a/src/components/logged-in/transactions/transactions-pagination.tsx
+++ b/src/components/logged-in/transactions/transactions-pagination.tsx
@@ -19,7 +19,7 @@ interface TransactionsPaginationProps {
 export function TransactionsPagination({
   hasMore,
 }: TransactionsPaginationProps) {
-  const { pagination, setPagination } = usePagination()
+  const { pagination, setPagination } = usePagination('transactions')
 
   const currentPage = pagination.page
   const hasNextPage = hasMore

--- a/src/components/logged-in/uploads/filters/search-filter.tsx
+++ b/src/components/logged-in/uploads/filters/search-filter.tsx
@@ -18,7 +18,7 @@ const SEARCH_SHORTCUT = 'S'
 
 export function SearchFilter() {
   const { uploadsFilters, setUploadsFilters } = useUploadsFilters()
-  const { setPagination } = usePagination()
+  const { setPagination } = usePagination('uploads')
   const inputRef = useRef<HTMLInputElement>(null)
 
   const debouncedSetSearchParams = useDebounceCallback((value: string) => {

--- a/src/components/logged-in/uploads/loading-state.tsx
+++ b/src/components/logged-in/uploads/loading-state.tsx
@@ -15,7 +15,7 @@ const RANDOM_FIRST_COLUMN_SIZES = [
 ]
 
 export function LoadingState() {
-  const { pagination } = usePagination()
+  const { pagination } = usePagination('uploads')
 
   return (
     <>

--- a/src/components/logged-in/uploads/uploads-pagination.tsx
+++ b/src/components/logged-in/uploads/uploads-pagination.tsx
@@ -17,7 +17,7 @@ interface UploadsPaginationProps {
 }
 
 export function UploadsPagination({ hasMore }: UploadsPaginationProps) {
-  const { pagination, setPagination } = usePagination()
+  const { pagination, setPagination } = usePagination('uploads')
 
   const currentPage = pagination.page
   const hasNextPage = hasMore

--- a/src/hooks/use-categories.ts
+++ b/src/hooks/use-categories.ts
@@ -10,7 +10,7 @@ export function useCategories(
   } = {},
 ) {
   const { categoryFilters } = useCategoriesFilters()
-  const { pagination } = usePagination()
+  const { pagination } = usePagination('categories')
 
   return trpc.categories.list.useQuery({
     filters: {

--- a/src/hooks/use-categorization-rules.ts
+++ b/src/hooks/use-categorization-rules.ts
@@ -10,7 +10,7 @@ export function useCategorizationRules(
   } = {},
 ) {
   const { filters } = useCategorizationRulesFilters()
-  const { pagination } = usePagination()
+  const { pagination } = usePagination('categorization-rules')
 
   return trpc.categorizationRules.list.useQuery({
     filters: {

--- a/src/hooks/use-pagination.ts
+++ b/src/hooks/use-pagination.ts
@@ -1,11 +1,64 @@
-import { DEFAULT_LIMIT_PER_PAGE } from '@/constants/pagination'
+import {
+  DEFAULT_LIMIT_PER_PAGE,
+  LIMIT_PER_PAGE_OPTIONS,
+} from '@/constants/pagination'
 import { parseAsInteger, useQueryStates } from 'nuqs'
+import { useCallback, useEffect, useMemo } from 'react'
 
-export function usePagination() {
-  const [pagination, setPagination] = useQueryStates({
+export type PaginationPageKey =
+  | 'transactions'
+  | 'categories'
+  | 'uploads'
+  | 'categorization-rules'
+
+function getStorageKey(pageKey: PaginationPageKey): string {
+  return `pagination-limit-${pageKey}`
+}
+
+function getStoredLimit(pageKey: PaginationPageKey): number {
+  if (typeof window === 'undefined') return DEFAULT_LIMIT_PER_PAGE
+
+  const stored = localStorage.getItem(getStorageKey(pageKey))
+  if (!stored) return DEFAULT_LIMIT_PER_PAGE
+
+  const parsed = Number.parseInt(stored, 10)
+  if (Number.isNaN(parsed) || !LIMIT_PER_PAGE_OPTIONS.includes(parsed)) {
+    return DEFAULT_LIMIT_PER_PAGE
+  }
+
+  return parsed
+}
+
+function setStoredLimit(pageKey: PaginationPageKey, limit: number): void {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(getStorageKey(pageKey), String(limit))
+}
+
+export function usePagination(pageKey: PaginationPageKey) {
+  const storedLimit = useMemo(() => getStoredLimit(pageKey), [pageKey])
+
+  const [pagination, setQueryPagination] = useQueryStates({
     page: parseAsInteger.withDefault(1),
-    limit: parseAsInteger.withDefault(DEFAULT_LIMIT_PER_PAGE),
+    limit: parseAsInteger.withDefault(storedLimit),
   })
+
+  // Sync limit changes to localStorage
+  useEffect(() => {
+    if (pagination.limit !== storedLimit) {
+      setStoredLimit(pageKey, pagination.limit)
+    }
+  }, [pagination.limit, pageKey, storedLimit])
+
+  const setPagination = useCallback(
+    (updates: { page?: number; limit?: number }) => {
+      // If limit is being updated, also persist to localStorage
+      if (updates.limit !== undefined) {
+        setStoredLimit(pageKey, updates.limit)
+      }
+      return setQueryPagination(updates)
+    },
+    [pageKey, setQueryPagination],
+  )
 
   return {
     pagination,

--- a/src/hooks/use-transactions.ts
+++ b/src/hooks/use-transactions.ts
@@ -10,7 +10,7 @@ import { usePagination } from './use-pagination'
 
 export function useTransactions() {
   const { transactionFilters } = useTransactionsFilters()
-  const { pagination } = usePagination()
+  const { pagination } = usePagination('transactions')
 
   const { refetch: refetchCountToReview } = useCountToReview()
   const { refetch: refetchMostFrequentMerchant } = useMostFrequentMerchant()

--- a/src/hooks/use-uploads.ts
+++ b/src/hooks/use-uploads.ts
@@ -4,7 +4,7 @@ import { usePagination } from './use-pagination'
 
 export function useUploads() {
   const { uploadsFilters } = useUploadsFilters()
-  const { pagination } = usePagination()
+  const { pagination } = usePagination('uploads')
 
   return trpc.uploads.list.useQuery({
     filters: {


### PR DESCRIPTION
- Update usePagination hook to accept a pageKey parameter
- Store pagination limit in localStorage per page (e.g., pagination-limit-transactions)
- Sync localStorage with URL query params via nuqs
- URL params take precedence when present (for shareable links)
- Update all pagination components, data hooks, and filter components to use page-specific pagination keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured pagination state management to maintain separate pagination settings for each section (Transactions, Categories, Uploads, Categorization Rules). Pagination preferences are now persisted individually per section, allowing each view to retain its own page and limit settings independently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->