### PR TITLE
feat: store dashboard date filter in local storage

### DIFF
--- a/src/components/logged-in/dashboard/search-params.ts
+++ b/src/components/logged-in/dashboard/search-params.ts
@@ -12,11 +12,15 @@ const DEFAULT_PRESET: DatePreset = '30d'
 function getStoredPreset(): DatePreset {
   if (typeof window === 'undefined') return DEFAULT_PRESET
 
-  const stored = localStorage.getItem(STORAGE_KEY)
-  if (!stored) return DEFAULT_PRESET
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) return DEFAULT_PRESET
 
-  if (DATE_PRESETS.includes(stored as DatePreset)) {
-    return stored as DatePreset
+    if (DATE_PRESETS.includes(stored as DatePreset)) {
+      return stored as DatePreset
+    }
+  } catch {
+    // localStorage unavailable or blocked, fall through to default
   }
 
   return DEFAULT_PRESET
@@ -24,7 +28,11 @@ function getStoredPreset(): DatePreset {
 
 function setStoredPreset(preset: DatePreset): void {
   if (typeof window === 'undefined') return
-  localStorage.setItem(STORAGE_KEY, preset)
+  try {
+    localStorage.setItem(STORAGE_KEY, preset)
+  } catch {
+    // localStorage unavailable or blocked, silently fail
+  }
 }
 
 export function useDashboardFilters() {


### PR DESCRIPTION
Store the selected date filter preset in localStorage alongside URL query params, following the same pattern as pagination page size. This ensures users see their preferred date range when returning to the dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard date preset selections are persisted to local storage and automatically restored on return visits.
  * Preset changes sync with the URL and remain consistent across navigation.
  * New preset helpers: human-friendly labels, computed date ranges (including custom ranges), and automatic grouping granularity (day/week/month).

* **Behavior Change**
  * "Year-to-date" preset now ends at the current time instead of the end of the year.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->