### PR TITLE
fix: mobile responsiveness when editing a transaction

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -82,7 +82,7 @@ function CommandList({
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        'max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto',
+        'max-h-[min(300px,var(--radix-popover-content-available-height,300px))] scroll-py-1 overflow-x-hidden overflow-y-auto overscroll-contain',
         className,
       )}
       {...props}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -20,6 +20,7 @@ function PopoverContent({
   className,
   align = 'center',
   sideOffset = 4,
+  collisionPadding = 16,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
   return (
@@ -28,6 +29,7 @@ function PopoverContent({
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         className={cn(
           'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
           className,


### PR DESCRIPTION
- Add collision padding to PopoverContent to prevent overflow when opening upward on mobile devices
- Use Radix's available height CSS variable in CommandList to dynamically constrain max-height based on available viewport space
- Add overscroll-contain to prevent scroll chaining on mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable collision padding for popover components, enabling better control over spacing when popovers appear near screen edges.

* **Improvements**
  * Enhanced command list scrolling behavior to dynamically adapt to available space in popovers, improving usability in constrained layouts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->