### PR TITLE
claude/shared-date-range-filter-IAWME

### DIFF
--- a/src/components/logged-in/dashboard/dashboard-filters.tsx
+++ b/src/components/logged-in/dashboard/dashboard-filters.tsx
@@ -1,28 +1,16 @@
 'use client'
 
-import {
-  type DatePreset,
-  DateRangeFilter,
-} from '@/components/logged-in/shared/date-range-filter'
+import { DateRangeFilter } from '@/components/logged-in/shared/date-range-filter'
 import { useDashboardFilters } from './search-params'
 
 export function DashboardFilters() {
   const { filters, setFilters } = useDashboardFilters()
 
-  const handleFilterChange = (updates: {
-    preset?: DatePreset
-    from?: Date | null
-    to?: Date | null
-  }) => {
-    setFilters(updates)
-  }
-
   return (
     <DateRangeFilter
-      preset={filters.preset}
       from={filters.from}
       to={filters.to}
-      onFilterChange={handleFilterChange}
+      onFilterChange={setFilters}
     />
   )
 }

--- a/src/components/logged-in/dashboard/dashboard-filters.tsx
+++ b/src/components/logged-in/dashboard/dashboard-filters.tsx
@@ -1,94 +1,28 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
-import { Calendar } from '@/components/ui/calendar'
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover'
-import { cn } from '@/lib/utils'
-import { format } from 'date-fns'
-import { CalendarIcon } from 'lucide-react'
-import { useMemo, useState } from 'react'
-import {
-  DATE_PRESETS,
   type DatePreset,
-  getPresetLabel,
-  useDashboardFilters,
-} from './search-params'
+  DateRangeFilter,
+} from '@/components/logged-in/shared/date-range-filter'
+import { useDashboardFilters } from './search-params'
 
 export function DashboardFilters() {
   const { filters, setFilters } = useDashboardFilters()
-  const [isCalendarOpen, setIsCalendarOpen] = useState(false)
 
-  const selectedRange = useMemo(
-    () => ({
-      from: filters.from ? new Date(filters.from) : undefined,
-      to: filters.to ? new Date(filters.to) : undefined,
-    }),
-    [filters.from, filters.to],
-  )
-
-  const handlePresetClick = (preset: DatePreset) => {
-    if (preset === 'custom') {
-      setIsCalendarOpen(true)
-      return
-    }
-    setFilters({ preset, from: null, to: null })
-  }
-
-  const handleDateSelect = (range: { from?: Date; to?: Date } | undefined) => {
-    if (range?.from) {
-      setFilters({ from: range.from, preset: 'custom' })
-    }
-    if (range?.to) {
-      setFilters({ to: range.to, preset: 'custom' })
-      setIsCalendarOpen(false)
-    }
+  const handleFilterChange = (updates: {
+    preset?: DatePreset
+    from?: Date | null
+    to?: Date | null
+  }) => {
+    setFilters(updates)
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      {DATE_PRESETS.filter((p) => p !== 'custom').map((preset) => (
-        <Button
-          key={preset}
-          variant={filters.preset === preset ? 'default' : 'outline'}
-          size="sm"
-          onClick={() => handlePresetClick(preset)}
-        >
-          {getPresetLabel(preset)}
-        </Button>
-      ))}
-
-      <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            variant={filters.preset === 'custom' ? 'default' : 'outline'}
-            size="sm"
-            className={cn(
-              'min-w-[140px] justify-start text-left font-normal',
-              filters.preset !== 'custom' && 'text-muted-foreground',
-            )}
-          >
-            <CalendarIcon className="mr-2 size-4" />
-            {filters.preset === 'custom' && filters.from && filters.to ? (
-              `${format(filters.from, 'MMM d')} - ${format(filters.to, 'MMM d')}`
-            ) : (
-              <span>Pick a date range</span>
-            )}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-auto p-0" align="start">
-          <Calendar
-            mode="range"
-            selected={selectedRange}
-            onSelect={handleDateSelect}
-            captionLayout="dropdown"
-            numberOfMonths={2}
-          />
-        </PopoverContent>
-      </Popover>
-    </div>
+    <DateRangeFilter
+      preset={filters.preset}
+      from={filters.from}
+      to={filters.to}
+      onFilterChange={handleFilterChange}
+    />
   )
 }

--- a/src/components/logged-in/dashboard/search-params.ts
+++ b/src/components/logged-in/dashboard/search-params.ts
@@ -1,104 +1,90 @@
 import {
   DATE_PRESETS,
   type DatePreset,
+  getActivePreset,
+  getDateRangeFromPreset,
 } from '@/components/logged-in/shared/date-range-filter'
 import { parseAsLocalDate } from '@/lib/utils'
-import { startOfYear, subDays, subMonths } from 'date-fns'
-import { parseAsStringLiteral, useQueryStates } from 'nuqs'
+import { useQueryStates } from 'nuqs'
 import { useCallback, useEffect, useRef } from 'react'
 
-export { DATE_PRESETS, type DatePreset }
-export { getPresetLabel } from '@/components/logged-in/shared/date-range-filter'
+export {
+  DATE_PRESETS,
+  type DatePreset,
+  getActivePreset,
+  getDateRangeFromPreset,
+}
 
 const STORAGE_KEY = 'dashboard-date-preset'
-const DEFAULT_PRESET: DatePreset = '30d'
+const DEFAULT_PRESET: Exclude<DatePreset, 'custom'> = '30d'
 
-function getStoredPreset(): DatePreset {
+function getStoredPreset(): Exclude<DatePreset, 'custom'> {
   if (typeof window === 'undefined') return DEFAULT_PRESET
 
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
     if (!stored) return DEFAULT_PRESET
 
-    if (DATE_PRESETS.includes(stored as DatePreset)) {
-      return stored as DatePreset
+    const validPresets = DATE_PRESETS.filter((p) => p !== 'custom')
+    if (validPresets.includes(stored as Exclude<DatePreset, 'custom'>)) {
+      return stored as Exclude<DatePreset, 'custom'>
     }
   } catch {
-    // localStorage unavailable or blocked, fall through to default
+    // localStorage unavailable or blocked
   }
 
   return DEFAULT_PRESET
 }
 
-function setStoredPreset(preset: DatePreset): void {
+function setStoredPreset(preset: Exclude<DatePreset, 'custom'>): void {
   if (typeof window === 'undefined') return
   try {
     localStorage.setItem(STORAGE_KEY, preset)
   } catch {
-    // localStorage unavailable or blocked, silently fail
+    // localStorage unavailable or blocked
   }
 }
 
 export function useDashboardFilters() {
-  const initialPreset = getStoredPreset()
-  const storedPresetRef = useRef<DatePreset>(initialPreset)
+  const initializedRef = useRef(false)
 
   const [filters, setQueryFilters] = useQueryStates({
-    preset: parseAsStringLiteral(DATE_PRESETS).withDefault(initialPreset),
     from: parseAsLocalDate,
     to: parseAsLocalDate,
   })
 
-  // Sync external URL changes (browser navigation) to localStorage
+  // Initialize from localStorage on first render if URL has no dates
   useEffect(() => {
-    if (filters.preset !== storedPresetRef.current) {
-      setStoredPreset(filters.preset)
-      storedPresetRef.current = filters.preset
+    if (initializedRef.current) return
+    initializedRef.current = true
+
+    if (!filters.from && !filters.to) {
+      const storedPreset = getStoredPreset()
+      const range = getDateRangeFromPreset(storedPreset)
+      setQueryFilters({ from: range.from, to: range.to })
     }
-  }, [filters.preset])
+  }, [filters.from, filters.to, setQueryFilters])
+
+  // Persist active preset to localStorage when dates change
+  const prevPresetRef = useRef<DatePreset | null>(null)
+  useEffect(() => {
+    if (!filters.from || !filters.to) return
+
+    const activePreset = getActivePreset(filters.from, filters.to)
+    if (activePreset !== 'custom' && activePreset !== prevPresetRef.current) {
+      setStoredPreset(activePreset)
+      prevPresetRef.current = activePreset
+    }
+  }, [filters.from, filters.to])
 
   const setFilters = useCallback(
-    (updates: {
-      preset?: DatePreset
-      from?: Date | null
-      to?: Date | null
-    }) => {
-      if (updates.preset !== undefined) {
-        setStoredPreset(updates.preset)
-        storedPresetRef.current = updates.preset
-      }
+    (updates: { from: Date; to: Date }) => {
       return setQueryFilters(updates)
     },
     [setQueryFilters],
   )
 
   return { filters, setFilters }
-}
-
-export function getDateRangeFromPreset(
-  preset: DatePreset,
-  customFrom?: Date | null,
-  customTo?: Date | null,
-): { from: Date; to: Date } {
-  const now = new Date()
-
-  switch (preset) {
-    case '7d':
-      return { from: subDays(now, 7), to: now }
-    case '30d':
-      return { from: subDays(now, 30), to: now }
-    case '3m':
-      return { from: subMonths(now, 3), to: now }
-    case '6m':
-      return { from: subMonths(now, 6), to: now }
-    case 'ytd':
-      return { from: startOfYear(now), to: now }
-    case 'custom':
-      return {
-        from: customFrom ?? subDays(now, 30),
-        to: customTo ?? now,
-      }
-  }
 }
 
 export function getGroupByFromPreset(

--- a/src/components/logged-in/dashboard/search-params.ts
+++ b/src/components/logged-in/dashboard/search-params.ts
@@ -1,10 +1,14 @@
+import {
+  DATE_PRESETS,
+  type DatePreset,
+} from '@/components/logged-in/shared/date-range-filter'
 import { parseAsLocalDate } from '@/lib/utils'
 import { startOfYear, subDays, subMonths } from 'date-fns'
 import { parseAsStringLiteral, useQueryStates } from 'nuqs'
 import { useCallback, useEffect, useRef } from 'react'
 
-export const DATE_PRESETS = ['7d', '30d', '3m', '6m', 'ytd', 'custom'] as const
-export type DatePreset = (typeof DATE_PRESETS)[number]
+export { DATE_PRESETS, type DatePreset }
+export { getPresetLabel } from '@/components/logged-in/shared/date-range-filter'
 
 const STORAGE_KEY = 'dashboard-date-preset'
 const DEFAULT_PRESET: DatePreset = '30d'
@@ -94,23 +98,6 @@ export function getDateRangeFromPreset(
         from: customFrom ?? subDays(now, 30),
         to: customTo ?? now,
       }
-  }
-}
-
-export function getPresetLabel(preset: DatePreset): string {
-  switch (preset) {
-    case '7d':
-      return 'Last 7 days'
-    case '30d':
-      return 'Last 30 days'
-    case '3m':
-      return 'Last 3 months'
-    case '6m':
-      return 'Last 6 months'
-    case 'ytd':
-      return 'Year to date'
-    case 'custom':
-      return 'Custom'
   }
 }
 

--- a/src/components/logged-in/dashboard/spending-by-category.tsx
+++ b/src/components/logged-in/dashboard/spending-by-category.tsx
@@ -12,7 +12,7 @@ import { trpc } from '@/lib/trpc/client'
 import { formatCurrency } from '@/lib/utils'
 import { format } from 'date-fns'
 import { Bar, BarChart, Cell, XAxis, YAxis } from 'recharts'
-import { getDateRangeFromPreset, useDashboardFilters } from './search-params'
+import { useDashboardFilters } from './search-params'
 
 const CHART_COLORS = [
   'var(--chart-1)',
@@ -31,17 +31,15 @@ const CHART_COLORS = [
 
 export function SpendingByCategory() {
   const { filters } = useDashboardFilters()
-  const { from, to } = getDateRangeFromPreset(
-    filters.preset,
-    filters.from,
-    filters.to,
-  )
 
-  const { data, isLoading } = trpc.dashboard.getSpendingByCategory.useQuery({
-    from: format(from, 'yyyy-MM-dd'),
-    to: format(to, 'yyyy-MM-dd'),
-    limit: 8,
-  })
+  const { data, isLoading } = trpc.dashboard.getSpendingByCategory.useQuery(
+    {
+      from: filters.from ? format(filters.from, 'yyyy-MM-dd') : '',
+      to: filters.to ? format(filters.to, 'yyyy-MM-dd') : '',
+      limit: 8,
+    },
+    { enabled: !!filters.from && !!filters.to },
+  )
 
   if (isLoading) {
     return (

--- a/src/components/logged-in/dashboard/spending-over-time.tsx
+++ b/src/components/logged-in/dashboard/spending-over-time.tsx
@@ -13,7 +13,7 @@ import { formatCurrency } from '@/lib/utils'
 import { format, parseISO } from 'date-fns'
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 import {
-  getDateRangeFromPreset,
+  getActivePreset,
   getGroupByFromPreset,
   useDashboardFilters,
 } from './search-params'
@@ -27,18 +27,17 @@ const chartConfig = {
 
 export function SpendingOverTime() {
   const { filters } = useDashboardFilters()
-  const { from, to } = getDateRangeFromPreset(
-    filters.preset,
-    filters.from,
-    filters.to,
-  )
-  const groupBy = getGroupByFromPreset(filters.preset)
+  const activePreset = getActivePreset(filters.from, filters.to)
+  const groupBy = getGroupByFromPreset(activePreset)
 
-  const { data, isLoading } = trpc.dashboard.getSpendingOverTime.useQuery({
-    from: format(from, 'yyyy-MM-dd'),
-    to: format(to, 'yyyy-MM-dd'),
-    groupBy,
-  })
+  const { data, isLoading } = trpc.dashboard.getSpendingOverTime.useQuery(
+    {
+      from: filters.from ? format(filters.from, 'yyyy-MM-dd') : '',
+      to: filters.to ? format(filters.to, 'yyyy-MM-dd') : '',
+      groupBy,
+    },
+    { enabled: !!filters.from && !!filters.to },
+  )
 
   if (isLoading) {
     return (

--- a/src/components/logged-in/dashboard/spending-summary-cards.tsx
+++ b/src/components/logged-in/dashboard/spending-summary-cards.tsx
@@ -11,7 +11,7 @@ import {
   TagIcon,
   TrendingUpIcon,
 } from 'lucide-react'
-import { getDateRangeFromPreset, useDashboardFilters } from './search-params'
+import { useDashboardFilters } from './search-params'
 
 function SummaryCardSkeleton() {
   return (
@@ -30,17 +30,15 @@ function SummaryCardSkeleton() {
 
 export function SpendingSummaryCards() {
   const { filters } = useDashboardFilters()
-  const { from, to } = getDateRangeFromPreset(
-    filters.preset,
-    filters.from,
-    filters.to,
-  )
 
   const { data: summary, isLoading } =
-    trpc.dashboard.getSpendingSummary.useQuery({
-      from: format(from, 'yyyy-MM-dd'),
-      to: format(to, 'yyyy-MM-dd'),
-    })
+    trpc.dashboard.getSpendingSummary.useQuery(
+      {
+        from: filters.from ? format(filters.from, 'yyyy-MM-dd') : '',
+        to: filters.to ? format(filters.to, 'yyyy-MM-dd') : '',
+      },
+      { enabled: !!filters.from && !!filters.to },
+    )
 
   if (isLoading) {
     return (

--- a/src/components/logged-in/dashboard/top-merchants.tsx
+++ b/src/components/logged-in/dashboard/top-merchants.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { trpc } from '@/lib/trpc/client'
 import { formatCurrency } from '@/lib/utils'
 import { format } from 'date-fns'
-import { getDateRangeFromPreset, useDashboardFilters } from './search-params'
+import { useDashboardFilters } from './search-params'
 
 function MerchantSkeleton() {
   return (
@@ -20,17 +20,15 @@ function MerchantSkeleton() {
 
 export function TopMerchants() {
   const { filters } = useDashboardFilters()
-  const { from, to } = getDateRangeFromPreset(
-    filters.preset,
-    filters.from,
-    filters.to,
-  )
 
-  const { data, isLoading } = trpc.dashboard.getTopMerchants.useQuery({
-    from: format(from, 'yyyy-MM-dd'),
-    to: format(to, 'yyyy-MM-dd'),
-    limit: 5,
-  })
+  const { data, isLoading } = trpc.dashboard.getTopMerchants.useQuery(
+    {
+      from: filters.from ? format(filters.from, 'yyyy-MM-dd') : '',
+      to: filters.to ? format(filters.to, 'yyyy-MM-dd') : '',
+      limit: 5,
+    },
+    { enabled: !!filters.from && !!filters.to },
+  )
 
   return (
     <Card>

--- a/src/components/logged-in/dashboard/transactions-to-review.tsx
+++ b/src/components/logged-in/dashboard/transactions-to-review.tsx
@@ -7,7 +7,7 @@ import { formatCurrency } from '@/lib/utils'
 import { format, parseISO } from 'date-fns'
 import { CheckCircleIcon } from 'lucide-react'
 import Link from 'next/link'
-import { getDateRangeFromPreset, useDashboardFilters } from './search-params'
+import { useDashboardFilters } from './search-params'
 
 function TransactionSkeleton() {
   return (
@@ -23,17 +23,15 @@ function TransactionSkeleton() {
 
 export function TransactionsToReview() {
   const { filters } = useDashboardFilters()
-  const { from, to } = getDateRangeFromPreset(
-    filters.preset,
-    filters.from,
-    filters.to,
-  )
 
-  const { data, isLoading } = trpc.dashboard.getTransactionsToReview.useQuery({
-    from: format(from, 'yyyy-MM-dd'),
-    to: format(to, 'yyyy-MM-dd'),
-    limit: 5,
-  })
+  const { data, isLoading } = trpc.dashboard.getTransactionsToReview.useQuery(
+    {
+      from: filters.from ? format(filters.from, 'yyyy-MM-dd') : '',
+      to: filters.to ? format(filters.to, 'yyyy-MM-dd') : '',
+      limit: 5,
+    },
+    { enabled: !!filters.from && !!filters.to },
+  )
 
   return (
     <Card>

--- a/src/components/logged-in/shared/date-range-filter.tsx
+++ b/src/components/logged-in/shared/date-range-filter.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils'
 import { format, isSameDay, startOfYear, subDays, subMonths } from 'date-fns'
 import { CalendarIcon } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import type { DateRange } from 'react-day-picker'
 
 export const DATE_PRESETS = ['7d', '30d', '3m', '6m', 'ytd', 'custom'] as const
 export type DatePreset = (typeof DATE_PRESETS)[number]
@@ -81,7 +82,7 @@ export function DateRangeFilter({
   onFilterChange,
 }: DateRangeFilterProps) {
   const [isCalendarOpen, setIsCalendarOpen] = useState(false)
-  const [localRange, setLocalRange] = useState<{ from?: Date; to?: Date }>({})
+  const [localRange, setLocalRange] = useState<DateRange | undefined>()
   const [clickCount, setClickCount] = useState(0)
 
   const activePreset = useMemo(() => getActivePreset(from, to), [from, to])
@@ -90,10 +91,11 @@ export function DateRangeFilter({
     setIsCalendarOpen(open)
     if (open) {
       setClickCount(0)
-      setLocalRange({
-        from: from ? new Date(from) : undefined,
-        to: to ? new Date(to) : undefined,
-      })
+      setLocalRange(
+        from
+          ? { from: new Date(from), to: to ? new Date(to) : undefined }
+          : undefined,
+      )
     }
   }
 
@@ -102,7 +104,7 @@ export function DateRangeFilter({
     onFilterChange(range)
   }
 
-  const handleDateSelect = (range: { from?: Date; to?: Date } | undefined) => {
+  const handleDateSelect = (range: DateRange | undefined) => {
     if (!range?.from) return
     const newClickCount = clickCount + 1
     setClickCount(newClickCount)

--- a/src/components/logged-in/shared/date-range-filter.tsx
+++ b/src/components/logged-in/shared/date-range-filter.tsx
@@ -7,7 +7,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
-import { cn } from '@/lib/utils'
 import { format, isSameDay, startOfYear, subDays, subMonths } from 'date-fns'
 import { CalendarIcon } from 'lucide-react'
 import { useMemo, useState } from 'react'
@@ -133,10 +132,7 @@ export function DateRangeFilter({
           <Button
             variant={activePreset === 'custom' ? 'default' : 'outline'}
             size="sm"
-            className={cn(
-              'min-w-[140px] justify-start text-left font-normal',
-              activePreset !== 'custom' && 'text-muted-foreground',
-            )}
+            className="min-w-[140px] justify-start text-left font-normal"
           >
             <CalendarIcon className="size-4" />
             {activePreset === 'custom' && from && to ? (

--- a/src/components/logged-in/shared/date-range-filter.tsx
+++ b/src/components/logged-in/shared/date-range-filter.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+import { format } from 'date-fns'
+import { CalendarIcon } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+export const DATE_PRESETS = ['7d', '30d', '3m', '6m', 'ytd', 'custom'] as const
+export type DatePreset = (typeof DATE_PRESETS)[number]
+
+export function getPresetLabel(preset: DatePreset): string {
+  switch (preset) {
+    case '7d':
+      return 'Last 7 days'
+    case '30d':
+      return 'Last 30 days'
+    case '3m':
+      return 'Last 3 months'
+    case '6m':
+      return 'Last 6 months'
+    case 'ytd':
+      return 'Year to date'
+    case 'custom':
+      return 'Custom'
+  }
+}
+
+interface DateRangeFilterProps {
+  preset: DatePreset
+  from: Date | null
+  to: Date | null
+  onFilterChange: (updates: {
+    preset?: DatePreset
+    from?: Date | null
+    to?: Date | null
+  }) => void
+}
+
+export function DateRangeFilter({
+  preset,
+  from,
+  to,
+  onFilterChange,
+}: DateRangeFilterProps) {
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false)
+
+  const selectedRange = useMemo(
+    () => ({
+      from: from ? new Date(from) : undefined,
+      to: to ? new Date(to) : undefined,
+    }),
+    [from, to],
+  )
+
+  const handlePresetClick = (selectedPreset: DatePreset) => {
+    if (selectedPreset === 'custom') {
+      setIsCalendarOpen(true)
+      return
+    }
+    onFilterChange({ preset: selectedPreset, from: null, to: null })
+  }
+
+  const handleDateSelect = (range: { from?: Date; to?: Date } | undefined) => {
+    if (range?.from) {
+      onFilterChange({ from: range.from, preset: 'custom' })
+    }
+    if (range?.to) {
+      onFilterChange({ to: range.to, preset: 'custom' })
+      setIsCalendarOpen(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {DATE_PRESETS.filter((p) => p !== 'custom').map((presetOption) => (
+        <Button
+          key={presetOption}
+          variant={preset === presetOption ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => handlePresetClick(presetOption)}
+        >
+          {getPresetLabel(presetOption)}
+        </Button>
+      ))}
+
+      <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant={preset === 'custom' ? 'default' : 'outline'}
+            size="sm"
+            className={cn(
+              'min-w-[140px] justify-start text-left font-normal',
+              preset !== 'custom' && 'text-muted-foreground',
+            )}
+          >
+            <CalendarIcon className="mr-2 size-4" />
+            {preset === 'custom' && from && to ? (
+              `${format(from, 'MMM d')} - ${format(to, 'MMM d')}`
+            ) : (
+              <span>Pick a date range</span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="range"
+            selected={selectedRange}
+            onSelect={handleDateSelect}
+            captionLayout="dropdown"
+            numberOfMonths={2}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/src/components/logged-in/transactions/filters/date-range-filter.tsx
+++ b/src/components/logged-in/transactions/filters/date-range-filter.tsx
@@ -1,116 +1,31 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
-import { Calendar } from '@/components/ui/calendar'
-import { Kbd } from '@/components/ui/kbd'
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+  type DatePreset,
+  DateRangeFilter as SharedDateRangeFilter,
+} from '@/components/logged-in/shared/date-range-filter'
 import { usePagination } from '@/hooks/use-pagination'
-import { cn } from '@/lib/utils'
-import { format } from 'date-fns'
-import { CalendarIcon, XIcon } from 'lucide-react'
-import { useState } from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
 import { useTransactionsFilters } from './search-params'
-
-const DATE_RANGE_SHORTCUT = 'D'
 
 export function DateRangeFilter() {
   const { transactionFilters, setTransactionFilters } = useTransactionsFilters()
   const { setPagination } = usePagination('transactions')
-  const [isOpen, setIsOpen] = useState(false)
 
-  const hasValues = !!transactionFilters.from && !!transactionFilters.to
-
-  const handleClear = (e: React.MouseEvent) => {
-    e.stopPropagation() // Prevent popover from opening
-    setTransactionFilters({
-      from: null,
-      to: null,
-    })
+  const handleFilterChange = (updates: {
+    preset?: DatePreset
+    from?: Date | null
+    to?: Date | null
+  }) => {
+    setTransactionFilters(updates)
     setPagination({ page: 1 })
   }
 
-  useHotkeys(DATE_RANGE_SHORTCUT, (e) => {
-    e.preventDefault()
-    setIsOpen(!isOpen)
-  })
-
   return (
-    <Tooltip>
-      <Popover open={isOpen} onOpenChange={setIsOpen}>
-        <TooltipTrigger asChild>
-          <PopoverTrigger asChild>
-            <Button
-              variant="outline"
-              className={cn(
-                'pl-3 text-left font-normal active:scale-100 w-full',
-                !hasValues && 'text-muted-foreground',
-              )}
-            >
-              {!!transactionFilters.from && !!transactionFilters.to ? (
-                `${format(transactionFilters.from, 'PP')} - ${format(transactionFilters.to, 'PP')}`
-              ) : (
-                <span>Pick a date range</span>
-              )}
-              <div className="ml-auto flex items-center">
-                {hasValues ? (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={handleClear}
-                    aria-label="Clear date range"
-                    className="size-7 -mr-1.5"
-                  >
-                    <XIcon className="opacity-50" />
-                  </Button>
-                ) : (
-                  <CalendarIcon className="size-4 opacity-50" />
-                )}
-              </div>
-            </Button>
-          </PopoverTrigger>
-        </TooltipTrigger>
-        <PopoverContent className="w-auto p-0" align="start">
-          <Calendar
-            mode="range"
-            selected={{
-              from: transactionFilters.from
-                ? new Date(transactionFilters.from)
-                : undefined,
-              to: transactionFilters.to
-                ? new Date(transactionFilters.to)
-                : undefined,
-            }}
-            onSelect={(value) => {
-              if (value?.from) {
-                setTransactionFilters({
-                  from: value.from,
-                })
-              }
-              if (value?.to) {
-                setTransactionFilters({
-                  to: value.to,
-                })
-              }
-              setPagination({ page: 1 })
-            }}
-            captionLayout="dropdown"
-          />
-        </PopoverContent>
-      </Popover>
-      <TooltipContent>
-        Or press <Kbd variant="outline">{DATE_RANGE_SHORTCUT}</Kbd> to pick a
-        date range
-      </TooltipContent>
-    </Tooltip>
+    <SharedDateRangeFilter
+      preset={transactionFilters.preset}
+      from={transactionFilters.from}
+      to={transactionFilters.to}
+      onFilterChange={handleFilterChange}
+    />
   )
 }

--- a/src/components/logged-in/transactions/filters/date-range-filter.tsx
+++ b/src/components/logged-in/transactions/filters/date-range-filter.tsx
@@ -1,9 +1,6 @@
 'use client'
 
-import {
-  type DatePreset,
-  DateRangeFilter as SharedDateRangeFilter,
-} from '@/components/logged-in/shared/date-range-filter'
+import { DateRangeFilter as SharedDateRangeFilter } from '@/components/logged-in/shared/date-range-filter'
 import { usePagination } from '@/hooks/use-pagination'
 import { useTransactionsFilters } from './search-params'
 
@@ -11,18 +8,13 @@ export function DateRangeFilter() {
   const { transactionFilters, setTransactionFilters } = useTransactionsFilters()
   const { setPagination } = usePagination('transactions')
 
-  const handleFilterChange = (updates: {
-    preset?: DatePreset
-    from?: Date | null
-    to?: Date | null
-  }) => {
+  const handleFilterChange = (updates: { from: Date; to: Date }) => {
     setTransactionFilters(updates)
     setPagination({ page: 1 })
   }
 
   return (
     <SharedDateRangeFilter
-      preset={transactionFilters.preset}
       from={transactionFilters.from}
       to={transactionFilters.to}
       onFilterChange={handleFilterChange}

--- a/src/components/logged-in/transactions/filters/index.tsx
+++ b/src/components/logged-in/transactions/filters/index.tsx
@@ -12,7 +12,7 @@ export function TransactionsFilters() {
   return (
     <>
       <DateRangeFilter />
-      <div className="grid grid-cols-1 xl:grid-cols-4 gap-2">
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-2">
         <SearchFilter />
         <CategoryFilter />
         <UploadFilter />

--- a/src/components/logged-in/transactions/filters/index.tsx
+++ b/src/components/logged-in/transactions/filters/index.tsx
@@ -11,9 +11,9 @@ import { UploadFilter } from './upload-filter'
 export function TransactionsFilters() {
   return (
     <>
-      <div className="grid grid-cols-1 xl:grid-cols-5 gap-2">
+      <DateRangeFilter />
+      <div className="grid grid-cols-1 xl:grid-cols-4 gap-2">
         <SearchFilter />
-        <DateRangeFilter />
         <CategoryFilter />
         <UploadFilter />
       </div>

--- a/src/components/logged-in/transactions/filters/index.tsx
+++ b/src/components/logged-in/transactions/filters/index.tsx
@@ -12,7 +12,7 @@ export function TransactionsFilters() {
   return (
     <>
       <DateRangeFilter />
-      <div className="grid grid-cols-1 xl:grid-cols-3 gap-2">
+      <div className="grid grid-cols-1 xl:grid-cols-4 gap-2">
         <SearchFilter />
         <CategoryFilter />
         <UploadFilter />

--- a/src/components/logged-in/transactions/filters/search-params.ts
+++ b/src/components/logged-in/transactions/filters/search-params.ts
@@ -1,15 +1,87 @@
+import {
+  DATE_PRESETS,
+  type DatePreset,
+} from '@/components/logged-in/shared/date-range-filter'
 import { parseAsLocalDate } from '@/lib/utils'
-import { parseAsArrayOf, parseAsString, useQueryStates } from 'nuqs'
+import {
+  parseAsArrayOf,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryStates,
+} from 'nuqs'
+import { useCallback, useEffect, useRef } from 'react'
+
+const STORAGE_KEY = 'transactions-date-preset'
+const DEFAULT_PRESET: DatePreset = '30d'
+
+function getStoredPreset(): DatePreset {
+  if (typeof window === 'undefined') return DEFAULT_PRESET
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) return DEFAULT_PRESET
+
+    if (DATE_PRESETS.includes(stored as DatePreset)) {
+      return stored as DatePreset
+    }
+  } catch {
+    // localStorage unavailable or blocked, fall through to default
+  }
+
+  return DEFAULT_PRESET
+}
+
+function setStoredPreset(preset: DatePreset): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, preset)
+  } catch {
+    // localStorage unavailable or blocked, silently fail
+  }
+}
 
 export function useTransactionsFilters() {
-  const [transactionFilters, setTransactionFilters] = useQueryStates({
+  const initialPreset = getStoredPreset()
+  const storedPresetRef = useRef<DatePreset>(initialPreset)
+
+  const [transactionFilters, setQueryFilters] = useQueryStates({
     category: parseAsString.withDefault('all'),
+    preset: parseAsStringLiteral(DATE_PRESETS).withDefault(initialPreset),
     from: parseAsLocalDate,
     to: parseAsLocalDate,
     query: parseAsString.withDefault(''),
     ids: parseAsArrayOf(parseAsString).withDefault([]),
     uploadId: parseAsString.withDefault('all'),
   })
+
+  // Sync external URL changes (browser navigation) to localStorage
+  useEffect(() => {
+    if (transactionFilters.preset !== storedPresetRef.current) {
+      setStoredPreset(transactionFilters.preset)
+      storedPresetRef.current = transactionFilters.preset
+    }
+  }, [transactionFilters.preset])
+
+  const setTransactionFilters = useCallback(
+    (
+      updates: Partial<{
+        category: string | null
+        preset: DatePreset
+        from: Date | null
+        to: Date | null
+        query: string | null
+        ids: string[] | null
+        uploadId: string | null
+      }>,
+    ) => {
+      if (updates.preset !== undefined) {
+        setStoredPreset(updates.preset)
+        storedPresetRef.current = updates.preset
+      }
+      return setQueryFilters(updates)
+    },
+    [setQueryFilters],
+  )
 
   return {
     transactionFilters,


### PR DESCRIPTION
Extract date range filter with presets from dashboard into a shared component and use it in both dashboard and transactions pages. This provides consistent date filtering UX across the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date preset preference for transaction filters now persists across sessions.
  * New shared date range control with quick presets (7d, 30d, 3m, 6m, YTD) and a two-month custom range picker.

* **UI/UX Improvements**
  * Consolidated and simplified date-range filtering across dashboard and transactions.
  * Date range control moved above filters for easier access.
  * Data panels now load only when an explicit date range is set, reducing unnecessary queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->